### PR TITLE
Remove warning "scrollEventThrottle" from iOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -408,6 +408,7 @@ export default class Carousel extends Component {
           onScrollBeginDrag={this._onScrollBegin}
           onMomentumScrollEnd={this._onScrollEnd}
           onScroll={this._onScroll}
+          scrollEventThrottle={0}
           alwaysBounceHorizontal={false}
           alwaysBounceVertical={false}
           contentInset={{ top: 0 }}


### PR DESCRIPTION
When using on iOS it throws a warning: 
```
You specified `onScroll` on a <ScrollView> but not `scrollEventThrottle`. You will only receive one event. Using `16` you get all the events but be aware that it may cause frame drops, use a bigger number if you don't need as much precision.
```
Just setting it to `0` the default value, takes the warning away and everything keeps normal